### PR TITLE
Ignore null properties inside JSON

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
+++ b/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
@@ -84,6 +84,8 @@ public class SchemaTransformer {
                 SchemaBuilder.array(childSchema).name(key+"_array").build(),
                 transformedChildren
             );
+        } else if (obj == null) {
+            return null;
         }
 
         SchemaBuilder schemaBuilder = new SchemaBuilder(Values.inferSchema(obj).type());

--- a/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
@@ -65,6 +65,26 @@ public class DebeziumJsonDeserializerTest {
     }
 
     @Test
+    public void ignoresANullValueWithinProperty() {
+        Struct value = new Struct(simpleSchema);
+        value.put("id", "1234-5678");
+        value.put("json", "{\"foo\": \"bar\", \"baz\": null}");
+
+        final SourceRecord transformedRecord = doTransform(value);
+
+        Schema transformedValueSchema = transformedRecord.valueSchema();
+
+        assertNotNull(transformedValueSchema);
+        assertNotNull(transformedValueSchema.field("id"));
+        assertNotNull(transformedValueSchema.field("json"));
+
+        Schema jsonSchema = transformedValueSchema.field("json").schema();
+        assertEquals(Schema.Type.STRUCT, jsonSchema.type());
+        assertNotNull(jsonSchema.field("foo"));
+        assertNull(jsonSchema.field("baz"));
+    }
+
+    @Test
     public void transformsAStruct() {
         Struct value = new Struct(simpleSchema);
         value.put("id", "1234-5678");


### PR DESCRIPTION
The following event
```
{
    "id": "aaaa-bbbb",
    "json": "{\"user_id\":null, \"received_at\":\"2021-03-31T10:03:51.966Z\"}"
}
```
should return the following schema:
```
{
    "id": STRING,
    "json": 
        {"received_at": STRING}
}
```