### PR TITLE
Children structures should be optional with optional-struct-fields param

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
+++ b/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
@@ -33,7 +33,8 @@ public class SchemaTransformer {
                     key,
                     (Set<Map.Entry<String, Object>>) object.entrySet(),
                     entry -> entry.getKey(),
-                    entry -> transformJsonValue(entry.getValue(), key+"_"+entry.getKey())
+                    entry -> transformJsonValue(entry.getValue(), key+"_"+entry.getKey()),
+                    optionalStructFields
             );
         } else if (obj instanceof JSONArray) {
             Schema childSchema = null;
@@ -77,13 +78,23 @@ public class SchemaTransformer {
 
             // By default, if array is empty, it's an empty struct
             if (childSchema == null) {
-                childSchema = SchemaBuilder.struct().name(key+"_array_item").build();
+                SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+                if (optionalStructFields) {
+                    schemaBuilder.optional();
+                }
+                childSchema = schemaBuilder.name(key+"_array_item").build();
+            }
+
+            SchemaBuilder schemaBuilder = SchemaBuilder.array(childSchema);
+            if (optionalStructFields) {
+                schemaBuilder.optional();
             }
 
             return new SchemaAndValue(
-                SchemaBuilder.array(childSchema).name(key+"_array").build(),
+                schemaBuilder.name(key+"_array").build(),
                 transformedChildren
             );
+
         } else if (obj == null) {
             return null;
         }

--- a/src/main/java/com/birdie/kafka/connect/utils/StructWalker.java
+++ b/src/main/java/com/birdie/kafka/connect/utils/StructWalker.java
@@ -16,6 +16,16 @@ public class StructWalker {
             Function<T, String> identifierFn,
             Function<T, SchemaAndValue> transformerFn
     ) {
+        return walk(name, items, identifierFn, transformerFn, false);
+    }
+
+    public static <T> SchemaAndValue walk(
+            String name,
+            Collection<T> items,
+            Function<T, String> identifierFn,
+            Function<T, SchemaAndValue> transformerFn,
+            Boolean optionalStructFields
+    ) {
         SchemaBuilder builder = SchemaBuilder.struct().name(name);
         HashMap<String, Object> valuesPerField = new HashMap<>();
 
@@ -27,6 +37,10 @@ public class StructWalker {
                 builder.field(identifier, field.schema());
                 valuesPerField.put(identifier, field.value());
             }
+        }
+
+        if (optionalStructFields) {
+            builder.optional();
         }
 
         Schema newSchema = builder.build();

--- a/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
@@ -165,6 +165,27 @@ public class DebeziumJsonDeserializerTest {
     }
 
     @Test
+    public void transformsAnJsonOfDifferentStructsWithOptionalFields() {
+        Struct value = new Struct(simpleSchema);
+        value.put("id", "1234-5678");
+        value.put("json", "{\n" +
+                "  \"field1\": {\"type\": \"care_task\", \"id\": \"48385242-96d5-11eb-b8f1-4fc97a48a234\", \"note\": \"My note\", \"task_definition_id\": \"1234\"},\n" +
+                "  \"field2\": 100\n" +
+                "}");
+
+        final SourceRecord transformedRecord = doTransform(value, new HashMap<>() {{
+           put("optional-struct-fields", "true");
+        }});
+
+        Schema transformedValueSchema = transformedRecord.valueSchema();
+
+        Schema jsonSchema = transformedValueSchema.field("json").schema();
+        assertTrue(jsonSchema.field("field1").schema().isOptional());
+        assertTrue(jsonSchema.field("field2").schema().isOptional());
+        assertTrue(jsonSchema.field("field1").schema().field("type").schema().isOptional());
+    }
+
+    @Test
     public void transformsEmptyArray() {
         Struct value = new Struct(simpleSchema);
         value.put("id", "1234-5678");


### PR DESCRIPTION
Currently, only simple fields are rendered optional with the `optional-struct-fields` option.
Nested structures should also be optional.