### PR TITLE
Fix union struct schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .idea
 *.iml
+.classpath
+.project
+.settings/
+.vscode/
 
 /target

--- a/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
+++ b/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
@@ -137,7 +137,7 @@ public class SchemaTransformer {
                 unionedSchema.optional();
             }
 
-            schemaBuilder.field(entry.getKey(), unionedSchema);
+            schemaBuilder.field(entry.getKey(), unionedSchema.build());
         }
 
         return schemaBuilder.build();

--- a/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
@@ -107,6 +107,23 @@ public class DebeziumJsonDeserializerTest {
     }
 
     @Test
+    public void transformsAnArrayOfStruct() {
+        Struct value = new Struct(simpleSchema);
+        value.put("id", "1234-5678");
+        value.put("json", "{\n" +
+                "  \"field1\": [{\"id\": 1}]\n" +
+                "  \"field2\": [{\"id\": 2}, {\"id\": 3}]\n" +
+                "}");
+
+        final SourceRecord transformedRecord = doTransform(value);
+
+        Schema jsonSchema = transformedRecord.valueSchema().field("json").schema();
+        assertEquals(Schema.Type.STRUCT, jsonSchema.type());
+        assertEquals(Schema.Type.ARRAY, jsonSchema.field("field1").schema().type());
+        assertEquals(jsonSchema.field("field1").schema().valueSchema().fields(), jsonSchema.field("field2").schema().valueSchema().fields());
+    }
+
+    @Test
     public void transformsAnArrayOfDifferentStructsWithRequiredCommonFields() {
         Struct value = new Struct(simpleSchema);
         value.put("id", "1234-5678");
@@ -165,7 +182,7 @@ public class DebeziumJsonDeserializerTest {
     }
 
     @Test
-    public void transformsAnJsonOfDifferentStructsWithOptionalFields() {
+    public void transformsAJsonOfDifferentStructsWithOptionalFields() {
         Struct value = new Struct(simpleSchema);
         value.put("id", "1234-5678");
         value.put("json", "{\n" +


### PR DESCRIPTION
Arrays going through UnionStruct function were returning an array of SchemaBuilder objects instead of schemas.
This meant that events with with single structs in arrays didn't have the same schema as those with multiple structs. 