### PR TITLE
Add option to convert numbers to doubles in JSON structs

### DIFF
--- a/doc/debezium-json-deserialization.md
+++ b/doc/debezium-json-deserialization.md
@@ -21,4 +21,4 @@ transforms.json.optional-struct-fields=true
 |Name|Description|Type|Default|
 |---|---|---|---|
 |`optional-struct-fields`| When `true`, all fields in structs are optional. This enables you to have slightly different types within each array item for example, so long that every field with the same name as the same type. | Boolean | `false` |
-
+|`convert-numbers-to-double`| When `true`, all number fields in structs are converted to double. This avoids compatibility errors when some fields can contain both integers and floats. | Boolean | `false` |

--- a/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
+++ b/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
@@ -15,6 +15,17 @@ public class SchemaTransformer {
     private boolean optionalStructFields;
     private boolean convertNumbersToDouble;
 
+    private static final Set<Schema.Type> numberSchemaTypes = new HashSet<Schema.Type>(Arrays.asList(
+        Schema.Type.INT8,
+        Schema.Type.INT16,
+        Schema.Type.INT32,
+        Schema.Type.INT64,
+        Schema.Type.FLOAT32
+    ));
+    private Boolean isNumberType(Schema.Type schemaType) {
+        return numberSchemaTypes.contains(schemaType);
+    }
+
     public SchemaTransformer(boolean optionalStructFields, boolean convertNumbersToDouble) {
         this.optionalStructFields = optionalStructFields;
         this.convertNumbersToDouble = convertNumbersToDouble;
@@ -102,8 +113,8 @@ public class SchemaTransformer {
         }
         
         Schema.Type objSchemaType = Values.inferSchema(obj).type();
-        
-        if (convertNumbersToDouble && objSchemaType == Schema.Type.INT64) {
+
+        if (convertNumbersToDouble && isNumberType(objSchemaType)) {
             obj = Double.valueOf(obj.toString());
             objSchemaType = Schema.Type.FLOAT64;
         }

--- a/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
+++ b/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
@@ -13,9 +13,11 @@ import java.util.stream.Stream;
 
 public class SchemaTransformer {
     private boolean optionalStructFields;
+    private boolean convertNumbersToDouble;
 
-    public SchemaTransformer(boolean optionalStructFields) {
+    public SchemaTransformer(boolean optionalStructFields, boolean convertNumbersToDouble) {
         this.optionalStructFields = optionalStructFields;
+        this.convertNumbersToDouble = convertNumbersToDouble;
     }
 
     public SchemaAndValue transform(Field field, String jsonValue) throws ParseException {
@@ -98,8 +100,15 @@ public class SchemaTransformer {
         } else if (obj == null) {
             return null;
         }
+        
+        Schema.Type objSchemaType = Values.inferSchema(obj).type();
+        
+        if (convertNumbersToDouble && objSchemaType == Schema.Type.INT64) {
+            obj = Double.valueOf(obj.toString());
+            objSchemaType = Schema.Type.FLOAT64;
+        }
 
-        SchemaBuilder schemaBuilder = new SchemaBuilder(Values.inferSchema(obj).type());
+        SchemaBuilder schemaBuilder = new SchemaBuilder(objSchemaType);
 
         if (optionalStructFields) {
             schemaBuilder.optional();

--- a/src/main/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializer.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializer.java
@@ -15,10 +15,12 @@ import java.util.Map;
 public class DebeziumJsonDeserializer implements Transformation<SourceRecord> {
     private interface ConfigName {
         String OPTIONAL_STRUCT_FIELDS = "optional-struct-fields";
+        String CONVERT_NUMBERS_TO_DOUBLE = "convert-numbers-to-double";
     }
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(ConfigName.OPTIONAL_STRUCT_FIELDS, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, "When true, all struct fields are optional.");
+            .define(ConfigName.OPTIONAL_STRUCT_FIELDS, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, "When true, all struct fields are optional.")
+            .define(ConfigName.CONVERT_NUMBERS_TO_DOUBLE, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, "When true, integers in structs are converted to doubles.");
 
     private SchemaTransformer schemaTransformer;
 
@@ -84,7 +86,8 @@ public class DebeziumJsonDeserializer implements Transformation<SourceRecord> {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
 
         schemaTransformer = new SchemaTransformer(
-                config.getBoolean(ConfigName.OPTIONAL_STRUCT_FIELDS)
+                config.getBoolean(ConfigName.OPTIONAL_STRUCT_FIELDS),
+                config.getBoolean(ConfigName.CONVERT_NUMBERS_TO_DOUBLE)
         );
     }
 }


### PR DESCRIPTION
When `convert-numbers-to-double` is set to `true`, all number fields in structs are converted to double. This avoids compatibility errors when some fields can contain both integers and floats.