### PR TITLE
Sanitise the name of schema in nested structures

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/utils/StructWalker.java
+++ b/src/main/java/com/birdie/kafka/connect/utils/StructWalker.java
@@ -16,7 +16,7 @@ public class StructWalker {
             Function<T, String> identifierFn,
             Function<T, SchemaAndValue> transformerFn
     ) {
-        return walk(name, items, identifierFn, transformerFn, false, false);
+        return walk(name, items, identifierFn, transformerFn, false);
     }
 
     public static <T> SchemaAndValue walk(
@@ -24,17 +24,13 @@ public class StructWalker {
             Collection<T> items,
             Function<T, String> identifierFn,
             Function<T, SchemaAndValue> transformerFn,
-            boolean optionalStructFields,
-            boolean sanitizeFieldsName
+            boolean optionalStructFields
     ) {
         SchemaBuilder builder = SchemaBuilder.struct().name(name);
         HashMap<String, Object> valuesPerField = new HashMap<>();
 
         for (T item: items) {
-            String identifier = sanitizeFieldsName
-                    ? AvroUtils.sanitizeColumnName(identifierFn.apply(item))
-                    : identifierFn.apply(item);
-
+            String identifier = identifierFn.apply(item);
             SchemaAndValue field = transformerFn.apply(item);
 
             if (field != null) {

--- a/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
@@ -307,7 +307,7 @@ public class DebeziumJsonDeserializerTest {
     public void itDoesProduceValidAvroNamesFromJsonProperties() {
         Struct value = new Struct(simpleSchema);
         value.put("id", "1234-5678");
-        value.put("json", "{\"with space\": 10, \"1some_details\":{\"sub key\": \"plop\"}}");
+        value.put("json", "{\"with space\": 10, \"1some_details\":{\"sub key\": \"plop\", \"_childrenNavigation\":{\"id-1611255248160-29\":{\"state\":{\"params\":{\"recipientId\":\"cd1a413e-446c-50bd-8b74-5e59606f383d\"}}}}}}");
 
         final SourceRecord transformedRecord = doTransform(value, new HashMap<>() {{
             put("sanitize.field.names", "true");
@@ -322,9 +322,12 @@ public class DebeziumJsonDeserializerTest {
 
         assertEquals(Schema.Type.STRUCT, jsonSchema.type());
         assertNotNull(jsonSchema.field("with_space"));
-        assertEquals("with_space", jsonSchema.field("with_space").name());
         assertNotNull(jsonSchema.field("_1some_details"));
+        assertEquals("json__1some_details", jsonSchema.field("_1some_details").schema().name());
         assertNotNull(jsonSchema.field("_1some_details").schema().field("sub_key"));
+        assertNotNull(jsonSchema.field("_1some_details").schema().field("_childrenNavigation"));
+        assertNotNull(jsonSchema.field("_1some_details").schema().field("_childrenNavigation").schema().field("id_1611255248160_29"));
+        assertEquals("json__1some_details__childrenNavigation_id_1611255248160_29", jsonSchema.field("_1some_details").schema().field("_childrenNavigation").schema().field("id_1611255248160_29").schema().name());
     }
 
     @Test


### PR DESCRIPTION
Otherwise we have invalid names, like:

```
Caused by: org.apache.avro.SchemaParseException: Illegal character in: payload_navigation__childrenNavigation_id-1611255248160-29
	at org.apache.avro.Schema.validateName(Schema.java:1530)
	at org.apache.avro.Schema.access$400(Schema.java:87)
	at org.apache.avro.Schema$Name.<init>(Schema.java:673)
	at org.apache.avro.Schema.createRecord(Schema.java:212)
```