### PR TITLE
Union schema in all list items and repackage list items

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/utils/LoggingContext.java
+++ b/src/main/java/com/birdie/kafka/connect/utils/LoggingContext.java
@@ -27,7 +27,11 @@ public class LoggingContext {
     }
 
     public static String describeSchema(Schema schema) {
+        if (schema == null) {
+            return null;
+        }
+
         return schema.toString()+" (#"+schema.hashCode()+") optional="+schema.isOptional()+" version="+schema.version()+" type="+schema.type()+" defaultValue="+schema.defaultValue()
-                + (schema.type().equals(Schema.Type.STRUCT) ? schema.fields() : "");
+                + (schema.type().equals(Schema.Type.STRUCT) ? " fields="+schema.fields() : "");
     }
 }

--- a/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializerTest.java
@@ -378,6 +378,19 @@ public class DebeziumJsonDeserializerTest {
     }
 
     @Test
+    public void transformsDifferentListItemsWithinStructWithinLists() {
+        Struct value = new Struct(simpleSchema);
+        value.put("id", "1234-5678");
+        value.put("json", "{\"a_list\": [{\"another_list\": []}, {\"another_list\": [{\"foo\": \"bar\"}]}]}");
+
+        final SourceRecord transformedRecord = doTransform(value);
+        Schema transformedValueSchema = transformedRecord.valueSchema();
+
+        assertNotNull(transformedValueSchema);
+        assertNotNull(transformedValueSchema.field("json"));
+    }
+
+    @Test
     public void skipsTombstones() {
         final SourceRecord record = new SourceRecord(
                 null, null, "test", 0,


### PR DESCRIPTION
Before, it was taking the first item's schema in a list as the source of truth: in some rare cases, that's not enough. 