### PR TITLE
Log valueTypes in error message when schema values dont match in unions

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
+++ b/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
@@ -195,7 +195,7 @@ public class SchemaTransformer {
                     .collect(Collectors.toList());
 
             if (valueTypes.size() != 1) {
-                throw new IllegalArgumentException("We can only union array schemas of the same value type together. Found: " + String.join(",", types));
+                throw new IllegalArgumentException("We can only union array schemas of the same value type together. Found: " + String.join(",", valueTypes));
             }
 
             return SchemaBuilder.array(


### PR DESCRIPTION
Error message now contains value type instead of schema type when values don't match.