### PR TITLE
fix: Uses the string value, not its string representation

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
+++ b/src/main/java/com/birdie/kafka/connect/json/SchemaTransformer.java
@@ -298,7 +298,7 @@ public class SchemaTransformer {
         } else if (node.isNumber()) {
             return node.numberValue();
         } else if (node.getNodeType() == JsonNodeType.STRING) {
-            return node.toString();
+            return node.textValue();
         }
 
         throw new IllegalArgumentException("Found JSON node of type '"+node.getNodeType()+"' but not supported.");


### PR DESCRIPTION
The performance improvements in #18 introduced a bug for string values that somehow we didn't catch in a test (🤯), the strings were their string representation (i.e. `"foo"`) instead of just their value (i.e. `foo`).