### PR TITLE
Allow to ignore array items

### DIFF
--- a/doc/debezium-json-deserialization.md
+++ b/doc/debezium-json-deserialization.md
@@ -27,7 +27,7 @@ transforms.json.optional-struct-fields=true
 |`convert-numbers-to-double`| When `true`, all number fields in structs are converted to double. This avoids compatibility errors when some fields can contain both integers and floats. | Boolean | `false` |
 |`sanitize.field.names`| When `true`, sanitizes the fields name so they are compatible with Avro; [like with Debezium.](https://debezium.io/documentation/reference/1.4/configuration/avro.html#avro-naming) | Boolean | `false` |
 |`probabilistic-fast-path`| When `true`, the connectors will first try to map the message to one of the known schemas if it exists (works with `union-previous-messages-schema`). If that's your most common path, this yields much higher performances. | Boolean | `false`
-|`ignored-fields`| An array of fields to be excluded from all schemas. E.g. `"column_name.json_field_1,column_name.json_field_2.sub_field"` | String | ø |
+|`ignored-fields`| An array of fields to be excluded from all schemas. E.g. `"column_name.json_field_1,column_name.json_field_2.an_array[].sub_field"` | String | ø |
 
 ## Benchmark
 

--- a/src/main/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializer.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/DebeziumJsonDeserializer.java
@@ -127,8 +127,8 @@ public class DebeziumJsonDeserializer implements Transformation<SourceRecord> {
         useProbabilisticFastPath = config.getBoolean(ConfigName.PROBABILISTIC_FAST_PATH);
         List<String> ignoredFields = new ArrayList<String>();
         for (String field: config.getString(ConfigName.IGNORED_FIELDS).split(",")) {
-            ignoredFields.add(field.replace('.', '_'));
-          }
+            ignoredFields.add(field.replace('.', '_').replace("[]", "_array_item"));
+        }
 
         if (unionPreviousMessagesSchema) {
             String fieldSchemaConfigurationPrefix = ConfigName.UNION_PREVIOUS_MESSAGES_SCHEMA+".topic.";


### PR DESCRIPTION
This is an alternative to https://github.com/birdiecare/connect-smts/pull/25 @ChloePont. The code is simpler and the syntax in the `ignored-fields` represents the fact we are talking about an array, which means we can have different ignore rules if a field is an array or an object.