### PR TITLE
feat: Add Outbox SMTs for integration events support

### DIFF
--- a/doc/outbox.md
+++ b/doc/outbox.md
@@ -16,6 +16,7 @@ message key. You can therefore maintain ordering for an aggregate while removing
 The transformed message is expected to have the following fields (if you use Debezium, the table is expected to contain 
 the following columns and [to have been flattened](https://debezium.io/documentation/reference/transformations/event-flattening.html)):
 - `payload`
+- `topic` (optional, can be configured at the SMT level)
 - `partition_number` or `partition_key`
 - `headers` (optional)
 

--- a/doc/outbox.md
+++ b/doc/outbox.md
@@ -1,0 +1,34 @@
+# Outbox
+
+The [outbox pattern](https://microservices.io/patterns/data/transactional-outbox.html) enables to reliably send messages
+to a message bus / event streaming platform. 
+
+The usual outbox SMT ([like Debezium's](https://debezium.io/documentation/reference/transformations/outbox-event-router.html))
+send all events of the same "aggregate" with the same key, so that multiple events related to the same user for instance
+end up in the same partition. However, it means that we can't enable compaction, meaning that we can't support deletion
+of events through tomstones.
+
+This SMT will take care of the partition routing (from a `partition_key`) while keeping the event identifier as the Kafka
+message key. You can therefore maintain ordering for an aggregate while removing individual events through compaction.
+
+## Usage
+
+The transformed message is expected to have the following fields (if you use Debezium, the table is expected to contain 
+the following columns and [to have been flattened](https://debezium.io/documentation/reference/transformations/event-flattening.html)):
+- `payload`
+- `partition_number` or `partition_key`
+- `headers` (optional)
+
+```
+transforms=outbox
+transforms.outbox.type=com.birdie.kafka.connect.smt.Outbox
+transforms.outbox.topic="target-topic"
+```
+
+## Properties
+
+|Name|Description|Type|Default|
+|---|---|---|---|
+|`topic`| The name of the topic to send messages to | String | ø |
+|`auto-partitioning`| If `true`, will decide the partition from the `partition_key` | String | `false` |
+|`num-partitions`| The number of partitions in your target topic | String | `false` |

--- a/doc/outbox.md
+++ b/doc/outbox.md
@@ -32,5 +32,5 @@ transforms.outbox.topic="target-topic"
 |---|---|---|---|
 |`topic`| The name of the topic to send messages to | String | ø |
 |`partition-setting`| If `partition-key`, will decide the partition from the `partition_key`, if `partition-number`, will pick directly from the `partition_number` column | String | `partition-number` |
-|`num-partitions`| The number of partitions in your target topic | String | `false` |
+|`num-partitions`| The number of partitions in your target topic. Alternatively, use `topic@3` to set your target topic being `topic`, with `3` partitions. | String | `false` |
 | `debug-log-level` | The log level setting (trace/debug/info) for debugging logs, to track exactly what record was received and what was transformed/sent | String | `trace`

--- a/doc/outbox.md
+++ b/doc/outbox.md
@@ -30,5 +30,6 @@ transforms.outbox.topic="target-topic"
 |Name|Description|Type|Default|
 |---|---|---|---|
 |`topic`| The name of the topic to send messages to | String | ø |
-|`auto-partitioning`| If `true`, will decide the partition from the `partition_key` | String | `false` |
+|`partition-setting`| If `partition-key`, will decide the partition from the `partition_key`, if `partition-number`, will pick directly from the `partition_number` column | String | `partition-number` |
 |`num-partitions`| The number of partitions in your target topic | String | `false` |
+| `debug-log-level` | The log level setting (trace/debug/info) for debugging logs, to track exactly what record was received and what was transformed/sent | String | `trace`

--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -20,7 +20,15 @@ public class Outbox implements Transformation<SourceRecord> {
 
     @java.lang.Override
     public SourceRecord apply(SourceRecord sourceRecord) {
-        return sourceRecord;
+        return sourceRecord.newRecord(
+                targetTopic,
+                sourceRecord.kafkaPartition(),
+                sourceRecord.keySchema(),
+                sourceRecord.key(),
+                sourceRecord.valueSchema(),
+                sourceRecord.value(),
+                sourceRecord.timestamp()
+        );
     }
 
 

--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -1,6 +1,7 @@
 package com.birdie.kafka.connect.smt;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
@@ -20,9 +21,12 @@ public class Outbox implements Transformation<SourceRecord> {
 
     @java.lang.Override
     public SourceRecord apply(SourceRecord sourceRecord) {
+        Struct value = (Struct) sourceRecord.value();
+        Integer partition = value.getInt32("partition_number");
+
         return sourceRecord.newRecord(
                 targetTopic,
-                sourceRecord.kafkaPartition(),
+                partition,
                 sourceRecord.keySchema(),
                 sourceRecord.key(),
                 sourceRecord.valueSchema(),

--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -22,15 +22,14 @@ public class Outbox implements Transformation<SourceRecord> {
     @java.lang.Override
     public SourceRecord apply(SourceRecord sourceRecord) {
         Struct value = (Struct) sourceRecord.value();
-        Integer partition = value.getInt32("partition_number");
 
         return sourceRecord.newRecord(
                 targetTopic,
-                partition,
+                value.getInt32("partition_number"),
                 sourceRecord.keySchema(),
                 sourceRecord.key(),
-                sourceRecord.valueSchema(),
-                sourceRecord.value(),
+                sourceRecord.valueSchema().field("payload").schema(),
+                value.get("payload"),
                 sourceRecord.timestamp()
         );
     }

--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -1,0 +1,42 @@
+package com.birdie.kafka.connect.smt;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.Map;
+
+public class Outbox implements Transformation<SourceRecord> {
+    private interface ConfigName {
+        String TOPIC = "topic";
+    }
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+        .define(Outbox.ConfigName.TOPIC, ConfigDef.Type.STRING, ConfigDef.Importance.MEDIUM, "The name of the topic to send messages to.")
+    ;
+
+    private String targetTopic;
+
+    @java.lang.Override
+    public SourceRecord apply(SourceRecord sourceRecord) {
+        return sourceRecord;
+    }
+
+
+    @java.lang.Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+
+        targetTopic = config.getString(ConfigName.TOPIC);
+    }
+
+    @java.lang.Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @java.lang.Override
+    public void close() {
+    }
+}

--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -1,14 +1,26 @@
 package com.birdie.kafka.connect.smt;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class Outbox implements Transformation<SourceRecord> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Outbox.class);
+
     private interface ConfigName {
         String TOPIC = "topic";
     }
@@ -18,12 +30,16 @@ public class Outbox implements Transformation<SourceRecord> {
     ;
 
     private String targetTopic;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @java.lang.Override
     public SourceRecord apply(SourceRecord sourceRecord) {
         Struct value = (Struct) sourceRecord.value();
 
-        return sourceRecord.newRecord(
+        Schema valueSchema = sourceRecord.valueSchema();
+        Field headerField = valueSchema.field("headers");
+
+        SourceRecord transformed = sourceRecord.newRecord(
                 targetTopic,
                 value.getInt32("partition_number"),
                 sourceRecord.keySchema(),
@@ -32,6 +48,40 @@ public class Outbox implements Transformation<SourceRecord> {
                 value.get("payload"),
                 sourceRecord.timestamp()
         );
+
+        if (headerField != null) {
+            if (!headerField.schema().type().equals(Schema.Type.STRING)) {
+                LOGGER.error("Field 'headers' should be a string.");
+            } else {
+                Headers headers = sourceRecord.headers();
+
+                try {
+                    HashMap<String, String> headersToBeAdded = objectMapper.readValue(
+                            value.getString("headers"),
+                            new TypeReference<HashMap<String, String>>() {}
+                    );
+
+                    for (String key : headersToBeAdded.keySet()) {
+                        headers.add(key, headersToBeAdded.get(key), Schema.STRING_SCHEMA);
+                    }
+
+                    transformed = sourceRecord.newRecord(
+                            sourceRecord.topic(),
+                            sourceRecord.kafkaPartition(),
+                            sourceRecord.keySchema(),
+                            sourceRecord.key(),
+                            sourceRecord.valueSchema(),
+                            sourceRecord.value(),
+                            sourceRecord.timestamp(),
+                            headers
+                    );
+                } catch (JsonProcessingException e) {
+                    LOGGER.error("Could not decode headers.", e);
+                }
+            }
+        }
+
+        return transformed;
     }
 
 

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -3,29 +3,36 @@ package com.birdie.kafka.connect.smt;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class OutboxTest {
+    private final Schema schema = SchemaBuilder.struct()
+            .name("Value")
+            .field("key", SchemaBuilder.STRING_SCHEMA)
+            .field("partition_number", SchemaBuilder.INT32_SCHEMA)
+            .field("payload", SchemaBuilder.string().name("io.debezium.data.Json").optional().build())
+            .build();
+
+    private final Schema schemaWithHeaders = SchemaBuilder.struct()
+            .name("Value")
+            .field("key", SchemaBuilder.STRING_SCHEMA)
+            .field("partition_number", SchemaBuilder.INT32_SCHEMA)
+            .field("payload", SchemaBuilder.string().name("io.debezium.data.Json").optional().build())
+            .field("headers", SchemaBuilder.string().name("io.debezium.data.Json").optional().build())
+            .build();
+
     @Test
     public void sendsAMessageToTheCorrectTopicPartition() {
         Outbox transformer = new Outbox();
         transformer.configure(new HashMap<>() {{
             put("topic", "caregivers.matches.v1");
         }});
-
-        Schema schema = SchemaBuilder.struct()
-                .name("Value")
-                .field("key", SchemaBuilder.STRING_SCHEMA)
-                // Later: `partition_key`, SMT will figure out the number of partition of the target topic by itself
-                .field("partition_number", SchemaBuilder.INT32_SCHEMA)
-                .field("payload", SchemaBuilder.string().name("io.debezium.data.Json").optional().build())
-            .build();
 
         Struct value = new Struct(schema);
         value.put("key", "1234");
@@ -50,5 +57,42 @@ public class OutboxTest {
         assertEquals("caregivers.matches.v1", transformedRecord.topic());
         assertNotNull(transformedRecord.kafkaPartition());
         assertEquals("1", transformedRecord.kafkaPartition().toString());
+    }
+
+    @Test
+    public void sendsAMessageWithHeaders() {
+        Outbox transformer = new Outbox();
+        transformer.configure(new HashMap<>() {{
+            put("topic", "caregivers.matches.v1");
+        }});
+
+        Struct value = new Struct(schemaWithHeaders);
+        value.put("key", "1234");
+        value.put("partition_number", 1);
+        value.put("payload", "[\"foo\", \"bar\"]");
+        value.put("headers", "{\"agency_id\": \"1234\"}");
+
+        SourceRecord record = new SourceRecord(
+                // Where it comes from
+                null, null,
+                // Where it is going
+                "a-database-name.public.the_database_table", null,
+                // Key
+                SchemaBuilder.bytes().optional().build(),
+                "1234".getBytes(),
+                // Value
+                schemaWithHeaders,
+                value
+        );
+
+        final SourceRecord transformedRecord = transformer.apply(record);
+
+        HashMap<String, Object> headersAsHashmap = new HashMap<>();
+        for (Header header : transformedRecord.headers()) {
+            headersAsHashmap.put(header.key(), header.value());
+        }
+
+        assertTrue(headersAsHashmap.containsKey("agency_id"));
+        assertEquals("1234", headersAsHashmap.get("agency_id"));
     }
 }

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -1,0 +1,52 @@
+package com.birdie.kafka.connect.smt;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+public class OutboxTest {
+    @Test
+    public void sendsAMessageToTheCorrectTopicPartition() {
+        Outbox transformer = new Outbox();
+        transformer.configure(new HashMap<>() {{
+            put("topic", "caregivers.matches.v1");
+        }});
+
+        Schema schema = SchemaBuilder.struct()
+                .name("Value")
+                .field("event_key", SchemaBuilder.STRING_SCHEMA)
+                // Later: `partition_key`, SMT will figure out the number of partition of the target topic by itself
+                .field("partition_number", SchemaBuilder.INT32_SCHEMA)
+                .field("payload", SchemaBuilder.string().name("io.debezium.data.Json").optional().build())
+            .build();
+
+        Struct value = new Struct(schema);
+        value.put("event_key", "1234");
+        value.put("partition_number", 1);
+        value.put("payload", "[\"foo\", \"bar\"]");
+
+        SourceRecord record = new SourceRecord(
+                // Where it comes from
+                null, null,
+                // Where it is going
+                "a-database-name.public.the_database_table", 0,
+                // Key
+                SchemaBuilder.bytes().optional().build(),
+                "1234".getBytes(),
+                // Value
+                schema,
+                value
+        );
+
+        final SourceRecord transformedRecord = transformer.apply(record);
+
+        assertEquals("caregivers.matches.v1", transformedRecord.topic());
+        assertEquals(1, transformedRecord.kafkaPartition());
+    }
+}

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class OutboxTest {
     @Test
@@ -47,6 +47,6 @@ public class OutboxTest {
         final SourceRecord transformedRecord = transformer.apply(record);
 
         assertEquals("caregivers.matches.v1", transformedRecord.topic());
-        assertEquals(1, transformedRecord.kafkaPartition());
+        assertEquals("1", transformedRecord.kafkaPartition().toString());
     }
 }

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -154,5 +154,13 @@ public class OutboxTest {
         assertEquals("caregivers.matches.v1", transformedRecord.topic());
         assertNotNull(transformedRecord.kafkaPartition());
         assertEquals("2", transformedRecord.kafkaPartition().toString());
+
+        HashMap<String, Object> headersAsHashmap = new HashMap<>();
+        for (Header header : transformedRecord.headers()) {
+            headersAsHashmap.put(header.key(), header.value());
+        }
+
+        assertTrue(headersAsHashmap.containsKey("partition_key"));
+        assertEquals("some-partition-key-value", headersAsHashmap.get("partition_key"));
     }
 }

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -71,6 +71,8 @@ public class OutboxTest {
         assertEquals("caregivers.matches.v1", transformedRecord.topic());
         assertNotNull(transformedRecord.kafkaPartition());
         assertEquals("1", transformedRecord.kafkaPartition().toString());
+        assertEquals("[\"foo\", \"bar\"]", transformedRecord.value());
+        assertEquals(Schema.Type.STRING, transformedRecord.valueSchema().type());
     }
 
     @Test

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -21,14 +21,14 @@ public class OutboxTest {
 
         Schema schema = SchemaBuilder.struct()
                 .name("Value")
-                .field("event_key", SchemaBuilder.STRING_SCHEMA)
+                .field("key", SchemaBuilder.STRING_SCHEMA)
                 // Later: `partition_key`, SMT will figure out the number of partition of the target topic by itself
                 .field("partition_number", SchemaBuilder.INT32_SCHEMA)
                 .field("payload", SchemaBuilder.string().name("io.debezium.data.Json").optional().build())
             .build();
 
         Struct value = new Struct(schema);
-        value.put("event_key", "1234");
+        value.put("key", "1234");
         value.put("partition_number", 1);
         value.put("payload", "[\"foo\", \"bar\"]");
 

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class OutboxTest {
     @Test
@@ -35,7 +36,7 @@ public class OutboxTest {
                 // Where it comes from
                 null, null,
                 // Where it is going
-                "a-database-name.public.the_database_table", 0,
+                "a-database-name.public.the_database_table", null,
                 // Key
                 SchemaBuilder.bytes().optional().build(),
                 "1234".getBytes(),
@@ -47,6 +48,7 @@ public class OutboxTest {
         final SourceRecord transformedRecord = transformer.apply(record);
 
         assertEquals("caregivers.matches.v1", transformedRecord.topic());
+        assertNotNull(transformedRecord.kafkaPartition());
         assertEquals("1", transformedRecord.kafkaPartition().toString());
     }
 }

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -118,7 +118,7 @@ public class OutboxTest {
             // TODO: test missing config
             // TODO: test with 1 partition, expected always being the same
 
-            put("num-target-partitions", 3);
+            put("num-partitions", 3);
         }});
 
         Schema schema = SchemaBuilder.struct()


### PR DESCRIPTION
Explained in the docs/tests - allow sending integration events to the right topic/partition.

One topic we hadn't discussed when pairing - how to handle deletions. Debezium emits two types of records in this situation (assuming we've enabled it on the `ExtractNewRecordState` SMT: empty tombstones and delete-rewrite records. I am dropping the tombstone because it doesn't have enough info to partition correctly, and am using the delete-rewrite to create a tombstone out of it.

Has been tested via local kafka cluster by sending HTTP requests to matching service using the setup in this PR - https://github.com/birdiecare/matching/pull/73