### PR TITLE
fix: Outbox tombstones to be sent with a `null` value and `null` schema

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -89,8 +89,8 @@ public class Outbox implements Transformation<SourceRecord> {
             transformedSchema = null;
             transformedValue = null;
         } else {
-            transformedSchema = sourceRecord.valueSchema().field("payload").schema();
             transformedValue = value.get("payload");
+            transformedSchema = transformedValue != null ? sourceRecord.valueSchema().field("payload").schema() : null;
         }
 
         String topic = targetTopic;

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -378,4 +378,37 @@ public class OutboxTest {
         assertEquals("my.topic.v1", transformedRecord.topic());
         assertEquals("2", transformedRecord.kafkaPartition().toString());
     }
+
+    @Test
+    public void sendsATombstoneWhenThePayloadIsNull() {
+        Struct value = new Struct(schemaWithPartitionKeyAndTopic);
+        value.put("key", "1234");
+        value.put("partition_key", "1234-5678");
+        value.put("topic", "my.topic.v1");
+        value.put("payload", null);
+
+        // Re-configure the outbox without a topic
+        transformer = new Outbox();
+        transformer.configure(new HashMap<>() {{
+            put("partition-setting", "partition-key");
+            put("num-partitions", 3);
+        }});
+
+        SourceRecord record = new SourceRecord(
+                null,
+                null,
+                "a-database-name.public.the_database_table",
+                null,
+                SchemaBuilder.bytes().optional().build(),
+                "1234".getBytes(),
+                schemaWithPartitionKeyAndTopic,
+                value
+        );
+
+        final SourceRecord transformedRecord = transformer.apply(record);
+        assertEquals("my.topic.v1", transformedRecord.topic());
+
+        assertNull(transformedRecord.value());
+        assertNull(transformedRecord.valueSchema());
+    }
 }


### PR DESCRIPTION
While this is minor, we want the schema to be `null` for tombstones created via the Outbox SMT.