### PR TITLE
fix: Allow the `Outbox` transformer to send empty and numeric header values

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -151,7 +151,7 @@ public class Outbox implements Transformation<SourceRecord> {
                         headers.add(
                             field.name(),
                             value.getStruct(HEADERS_FIELD).getString(field.name()),
-                            Schema.STRING_SCHEMA
+                            Schema.OPTIONAL_STRING_SCHEMA
                         );
                     });
                     break;
@@ -161,7 +161,7 @@ public class Outbox implements Transformation<SourceRecord> {
                             value.getString(HEADERS_FIELD),
                             new TypeReference<HashMap<String, String>>() {}
                         ).forEach((k, v) -> {
-                            headers.add(k, v, Schema.STRING_SCHEMA);
+                            headers.add(k, v, Schema.OPTIONAL_STRING_SCHEMA);
                         });
                     } catch (JsonProcessingException e) {
                         LOGGER.error("Could not decode headers.", e);

--- a/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
+++ b/src/test/java/com/birdie/kafka/connect/smt/OutboxTest.java
@@ -144,6 +144,30 @@ public class OutboxTest {
     }
 
     @Test
+    public void sendsAMessageWithHeadersContainingEmptyAndNumericValues() {
+        Struct value = new Struct(schemaWithStringHeaders);
+        value.put("key", "1234");
+        value.put("partition_number", 1);
+        value.put("payload", "[\"foo\", \"bar\"]");
+        value.put("headers", "{\"event_number\": 1234, \"agency_id\": null}");
+
+        SourceRecord record = new SourceRecord(
+                null,
+                null,
+                "a-database-name.public.the_database_table",
+                null,
+                SchemaBuilder.bytes().optional().build(),
+                "1234".getBytes(),
+                schemaWithStringHeaders,
+                value
+        );
+
+        final SourceRecord transformedRecord = transformer.apply(record);
+        assertEquals("1234", transformedRecord.headers().lastWithName("event_number").value());
+        assertNull(transformedRecord.headers().lastWithName("agency_id").value());
+    }
+
+    @Test
     public void sendsAMessageWithNullHeaders() {
         Struct value = new Struct(schemaWithStringHeaders);
         value.put("key", "1234");


### PR DESCRIPTION
Otherwise, processed messages erros with the following:
```
org.apache.kafka.connect.errors.DataException: A null value requires an optional schema but was Schema{STRING}
```