### PR TITLE
fix: Outbox must skip dbz_signal

### DIFF
--- a/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
+++ b/src/main/java/com/birdie/kafka/connect/smt/Outbox.java
@@ -70,6 +70,12 @@ public class Outbox implements Transformation<SourceRecord> {
     public SourceRecord apply(SourceRecord sourceRecord) {
         LOGGER.debug("Received source record: {}", sourceRecord);
 
+        /* Skipping messages from incremental snapshots */
+        if (sourceRecord.topic().toLowerCase().contains("dbz_signal")){
+            LOGGER.debug("Skipping dbz_signal record: {}", sourceRecord);
+            return sourceRecord;
+        }
+
         if (sourceRecord.value() == null) {
             LOGGER.debug("Dropping debezium-generated tombstones with null partition_key: {}", sourceRecord);
             return null;


### PR DESCRIPTION
Outbox is a Kafka Connect transformer to redirect the integration event to the right topic. The logic assumes that there is a field called `payload`, and that's true for integration events.
However, if we want to enable incremental snapshots, automatically the connector starts ingesting `public.dbz_signal` table used to managed custom snapshots. But that table doesn't contain `payload` field. So, we are going to skip in Outbox transformer all messages coming from `public.dbz_signal` topic.